### PR TITLE
Support toml file encodings for lock server configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.63.2
 replace github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 => github.com/alexandreLamarre/tempredis v0.0.0-20240129193023-7f411f64c2c7
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/go-redsync/redsync/v4 v4.13.0
 	github.com/google/uuid v1.6.0
 	github.com/jwalton/go-supportscolor v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
@@ -22,8 +24,6 @@ github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqy
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/containerd/containerd v1.7.12 h1:+KQsnv4VnzyxWcfO9mlxxELaoztsDEjOuCMPAuPqgU0=
-github.com/containerd/containerd v1.7.12/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
 github.com/containerd/containerd v1.7.15 h1:afEHXdil9iAm03BmhjzKyXnnEBtjaLJefdU7DV0IFes=
 github.com/containerd/containerd v1.7.15/go.mod h1:ISzRRTMF8EXNpJlTzyr2XMhN+j9K302C21/+cr3kUnY=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
@@ -121,8 +121,6 @@ github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=
 github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
-github.com/onsi/ginkgo/v2 v2.17.2 h1:7eMhcy3GimbsA3hEnVKdw/PQM9XN9krpKVXsZdph0/g=
-github.com/onsi/ginkgo/v2 v2.17.2/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
 github.com/onsi/ginkgo/v2 v2.17.3 h1:oJcvKpIb7/8uLpDDtnQuf18xVnwKp8DTD7DQ6gTd/MU=
 github.com/onsi/ginkgo/v2 v2.17.3/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
@@ -138,8 +136,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7kmXYlnfbA6JU=
-github.com/prometheus/client_golang v1.19.0/go.mod h1:ZRM9uEAypZakd+q/x7+gmsvXdURP+DABIEIjnmDdp+k=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
 github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
@@ -150,12 +146,8 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLBh8=
 github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
-github.com/redis/rueidis v1.0.35 h1:S1q50VYRl8Hg/ekcF5UPZsRXD4GYDLLU2b+oEogycnI=
-github.com/redis/rueidis v1.0.35/go.mod h1:bnbkk4+CkXZgDPEbUtSos/o55i4RhFYYesJ4DS2zmq0=
 github.com/redis/rueidis v1.0.36 h1:LfyASusbTvxVQjX9yl4FsafJ8Bl8ZvCHTnqdH/McZQc=
 github.com/redis/rueidis v1.0.36/go.mod h1:bnbkk4+CkXZgDPEbUtSos/o55i4RhFYYesJ4DS2zmq0=
-github.com/redis/rueidis/rueidiscompat v1.0.35 h1:r1WGL3Hmdl66n2hXClNevhbJvd0JL03wKE3uEvwyp58=
-github.com/redis/rueidis/rueidiscompat v1.0.35/go.mod h1:/Y2Ni3UkWCoUA+sdq2QVEb6nZQ7859VYgcGH1kaJQ98=
 github.com/redis/rueidis/rueidiscompat v1.0.36 h1:u4M3jfu1N5aS59S3NYbqddV1+MRqzEdoqPftiHuhFrU=
 github.com/redis/rueidis/rueidiscompat v1.0.36/go.mod h1:ERUkzG2Kb5e3ETpr16uVJu0ZxltfZqq5V58OSAH8F7Q=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -192,8 +184,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/testcontainers/testcontainers-go v0.30.0 h1:jmn/XS22q4YRrcMwWg0pAwlClzs/abopbsBzrepyc4E=
-github.com/testcontainers/testcontainers-go v0.30.0/go.mod h1:K+kHNGiM5zjklKjgTtcrEetF3uhWbMUyqAQoyoh8Pf0=
 github.com/testcontainers/testcontainers-go v0.31.0 h1:W0VwIhcEVhRflwL9as3dhY6jXjVCA27AkmbnZ+UTh3U=
 github.com/testcontainers/testcontainers-go v0.31.0/go.mod h1:D2lAoA0zUFiSY+eAflqK5mcUx/A5hrrORaEQrd0SefI=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
@@ -307,8 +297,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de/go.mod h1:H4O17MA/PE9BsGx3w+a+W2VOLLD1Qf7oJneAoU6WktY=
 google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
-google.golang.org/protobuf v1.34.0 h1:Qo/qEd2RZPCf2nKuorzksSknv0d3ERwp1vFG38gSmH4=
-google.golang.org/protobuf v1.34.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/config/v1alpha1/certs.go
+++ b/pkg/config/v1alpha1/certs.go
@@ -2,15 +2,15 @@ package v1alpha1
 
 type CertsSpec struct {
 	// Path to a PEM encoded CA certificate file. Mutually exclusive with CACertData
-	CACert *string `json:"caCert,omitempty"`
+	CACert *string `json:"caCert,omitempty" toml:"caCert"`
 	// String containing PEM encoded CA certificate data. Mutually exclusive with CACert
-	CACertData []byte `json:"caCertData,omitempty"`
+	CACertData []byte `json:"caCertData,omitempty" toml:"caCertData"`
 	// Path to a PEM encoded server certificate file. Mutually exclusive with ServingCertData
-	ServingCert *string `json:"servingCert,omitempty"`
+	ServingCert *string `json:"servingCert,omitempty" toml:"servingCert"`
 	// String containing PEM encoded server certificate data. Mutually exclusive with ServingCert
-	ServingCertData []byte `json:"servingCertData,omitempty"`
+	ServingCertData []byte `json:"servingCertData,omitempty" toml:"servingCertData"`
 	// Path to a PEM encoded server key file. Mutually exclusive with ServingKeyData
-	ServingKey *string `json:"servingKey,omitempty"`
+	ServingKey *string `json:"servingKey,omitempty" toml:"servingKey"`
 	// String containing PEM encoded server key data. Mutually exclusive with ServingKey
-	ServingKeyData []byte `json:"servingKeyData,omitempty"`
+	ServingKeyData []byte `json:"servingKeyData,omitempty" toml:"servingKeyData"`
 }

--- a/pkg/config/v1alpha1/config.go
+++ b/pkg/config/v1alpha1/config.go
@@ -1,9 +1,9 @@
 package v1alpha1
 
 type LockServerConfig struct {
-	EtcdClientSpec      *EtcdClientSpec      `json:"etcd,omitempty"`
-	JetstreamClientSpec *JetstreamClientSpec `json:"jetstream,omitempty"`
-	RedisClientSpec     *RedisClientSpec     `json:"redis,omitempty"`
+	EtcdClientSpec      *EtcdClientSpec      `json:"etcd,omitempty" toml:"etcd"`
+	JetstreamClientSpec *JetstreamClientSpec `json:"jetstream,omitempty" toml:"jetstream"`
+	RedisClientSpec     *RedisClientSpec     `json:"redis,omitempty" toml:"redis"`
 }
 
 type TracesConfig struct {

--- a/pkg/config/v1alpha1/etcd.go
+++ b/pkg/config/v1alpha1/etcd.go
@@ -2,18 +2,18 @@ package v1alpha1
 
 type EtcdClientSpec struct {
 	// List of etcd endpoints to connect to.
-	Endpoints []string `json:"endpoints,omitempty"`
+	Endpoints []string `json:"endpoints,omitempty" toml:"endpoints"`
 	// Configuration for etcd client-cert auth.
-	Certs *MTLSSpec `json:"certs,omitempty"`
+	Certs *MTLSSpec `json:"certs,omitempty" toml:"certs"`
 }
 
 type MTLSSpec struct {
 	// Path to the server CA certificate.
-	ServerCA string `json:"serverCA,omitempty"`
+	ServerCA string `json:"serverCA,omitempty" toml:"serverCA"`
 	// Path to the client CA certificate (not needed in all cases).
-	ClientCA string `json:"clientCA,omitempty"`
+	ClientCA string `json:"clientCA,omitempty" toml:"clientCA"`
 	// Path to the certificate used for client-cert auth.
-	ClientCert string `json:"clientCert,omitempty"`
+	ClientCert string `json:"clientCert,omitempty" toml:"clientCert"`
 	// Path to the private key used for client-cert auth.
-	ClientKey string `json:"clientKey,omitempty"`
+	ClientKey string `json:"clientKey,omitempty" toml:"clientKey"`
 }

--- a/pkg/config/v1alpha1/jetstream.go
+++ b/pkg/config/v1alpha1/jetstream.go
@@ -1,6 +1,6 @@
 package v1alpha1
 
 type JetstreamClientSpec struct {
-	Endpoint     string `json:"endpoint,omitempty"`
-	NkeySeedPath string `json:"nkeySeedPath,omitempty"`
+	Endpoint     string `json:"endpoint,omitempty" toml:"endpoint"`
+	NkeySeedPath string `json:"nkeySeedPath,omitempty" toml:"nkeySeedPath"`
 }

--- a/pkg/config/v1alpha1/redis.go
+++ b/pkg/config/v1alpha1/redis.go
@@ -1,6 +1,6 @@
 package v1alpha1
 
 type RedisClientSpec struct {
-	Network string `json:"network,omitempty"`
-	Addr    string `json:"addr,omitempty"`
+	Network string `json:"network,omitempty" toml:"network"`
+	Addr    string `json:"addr,omitempty" toml:"addr"`
 }

--- a/pkg/util/certs.go
+++ b/pkg/util/certs.go
@@ -39,17 +39,17 @@ func ParsePEMEncodedCert(data []byte) (*x509.Certificate, error) {
 
 type CertsSpecShape = struct {
 	// Path to a PEM encoded CA certificate file. Mutually exclusive with CACertData
-	CACert *string `json:"caCert,omitempty"`
+	CACert *string `json:"caCert,omitempty" toml:"caCert"`
 	// String containing PEM encoded CA certificate data. Mutually exclusive with CACert
-	CACertData []byte `json:"caCertData,omitempty"`
+	CACertData []byte `json:"caCertData,omitempty" toml:"caCertData"`
 	// Path to a PEM encoded server certificate file. Mutually exclusive with ServingCertData
-	ServingCert *string `json:"servingCert,omitempty"`
+	ServingCert *string `json:"servingCert,omitempty" toml:"servingCert"`
 	// String containing PEM encoded server certificate data. Mutually exclusive with ServingCert
-	ServingCertData []byte `json:"servingCertData,omitempty"`
+	ServingCertData []byte `json:"servingCertData,omitempty" toml:"servingCertData"`
 	// Path to a PEM encoded server key file. Mutually exclusive with ServingKeyData
-	ServingKey *string `json:"servingKey,omitempty"`
+	ServingKey *string `json:"servingKey,omitempty" toml:"servingKey"`
 	// String containing PEM encoded server key data. Mutually exclusive with ServingKey
-	ServingKeyData []byte `json:"servingKeyData,omitempty"`
+	ServingKeyData []byte `json:"servingKeyData,omitempty" toml:"servingKeyData"`
 }
 
 func LoadServingCertBundle(certsSpec CertsSpecShape) (*tls.Certificate, *x509.CertPool, error) {

--- a/pkg/util/mtls.go
+++ b/pkg/util/mtls.go
@@ -8,13 +8,13 @@ import (
 
 type MTLSSpecShape = struct {
 	// Path to the server CA certificate.
-	ServerCA string `json:"serverCA,omitempty"`
+	ServerCA string `json:"serverCA,omitempty" toml:"serverCA"`
 	// Path to the client CA certificate (not needed in all cases).
-	ClientCA string `json:"clientCA,omitempty"`
+	ClientCA string `json:"clientCA,omitempty" toml:"clientCA"`
 	// Path to the certificate used for client-cert auth.
-	ClientCert string `json:"clientCert,omitempty"`
+	ClientCert string `json:"clientCert,omitempty" toml:"clientCert"`
 	// Path to the private key used for client-cert auth.
-	ClientKey string `json:"clientKey,omitempty"`
+	ClientKey string `json:"clientKey,omitempty" toml:"clientKey"`
 }
 
 func LoadClientMTLSConfig(certs MTLSSpecShape) (*tls.Config, error) {


### PR DESCRIPTION
Example etcd encoding:
```
[etcd]
endpoints = [ "http://localhost:2379" ]
```