### PR TITLE
Implementing some extra lock modes

### DIFF
--- a/internal/lock/backend/etcd/lock.go
+++ b/internal/lock/backend/etcd/lock.go
@@ -21,7 +21,11 @@ type EtcdLock struct {
 	options *lock.LockOptions
 
 	scheduler *lock.LockScheduler
-
+	// !! Cannot reuse *concurrency.Session across multiple locks since it will break liveliness guarantee A
+	// locks will share their sessions and therefore keepalives will be sent for all locks, not just a specific lock.
+	// In the current implementation sessions are forcibly orphaned when the non-blocking call to unlock is
+	// made so we cannot re-use sessions in that case either -- since the session  will be orphaned for all locks
+	// if the session is re-used.
 	client *clientv3.Client
 	mutex  *etcdMutex
 }

--- a/internal/lock/backend/etcd/lock_manager.go
+++ b/internal/lock/backend/etcd/lock_manager.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alexandreLamarre/dlock/internal/lock/backend/unimplemented"
 	"github.com/alexandreLamarre/dlock/pkg/constants"
 	"github.com/alexandreLamarre/dlock/pkg/lock"
 	"github.com/alexandreLamarre/dlock/pkg/lock/broker"
@@ -83,11 +84,6 @@ func (e *EtcdLockManager) Health(ctx context.Context) (conditions []string, err 
 	return
 }
 
-// !! Cannot reuse *concurrency.Session across multiple locks since it will break liveliness guarantee A
-// locks will share their sessions and therefore keepalives will be sent for all locks, not just a specific lock.
-// In the current implementation sessions are forcibly orphaned when the non-blocking call to unlock is
-// made so we cannot re-use sessions in that case either -- since the session  will be orphaned for all locks
-// if the session is re-used.
 func (e *EtcdLockManager) NewLock(key string, opts ...lock.LockOption) lock.Lock {
 	options := lock.DefaultLockOptions()
 	options.Apply(opts...)
@@ -98,4 +94,24 @@ func (e *EtcdLockManager) NewLock(key string, opts ...lock.LockOption) lock.Lock
 		key,
 		options,
 	)
+}
+
+func (e *EtcdLockManager) EXLock(key string, opts ...lock.LockOption) lock.Lock {
+	return e.NewLock(key, opts...)
+}
+
+func (e *EtcdLockManager) PWLock(key string, opts ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+
+func (e *EtcdLockManager) PRLock(key string, opts ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+
+func (e *EtcdLockManager) CWLock(key string, opts ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+
+func (e *EtcdLockManager) CRLock(key string, opts ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
 }

--- a/internal/lock/backend/jetstream/lock_manager.go
+++ b/internal/lock/backend/jetstream/lock_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/alexandreLamarre/dlock/internal/lock/backend/unimplemented"
 	"github.com/alexandreLamarre/dlock/pkg/constants"
 	"github.com/alexandreLamarre/dlock/pkg/lock"
 	"github.com/alexandreLamarre/dlock/pkg/lock/broker"
@@ -72,4 +73,23 @@ func (l *LockManager) NewLock(key string, opts ...lock.LockOption) lock.Lock {
 	options := lock.DefaultLockOptions()
 	options.Apply(opts...)
 	return NewLock(l.js, l.prefix, key, l.lg, options)
+}
+
+func (l *LockManager) EXLock(key string, opts ...lock.LockOption) lock.Lock {
+	return l.NewLock(key, opts...)
+}
+
+func (l *LockManager) PWLock(_ string, _ ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+
+func (l *LockManager) PRLock(_ string, _ ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+func (l *LockManager) CWLock(_ string, _ ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+
+func (l *LockManager) CRLock(_ string, _ ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
 }

--- a/internal/lock/backend/redis/lock_manager.go
+++ b/internal/lock/backend/redis/lock_manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/alexandreLamarre/dlock/internal/lock/backend/unimplemented"
 	"github.com/alexandreLamarre/dlock/pkg/constants"
 	"github.com/alexandreLamarre/dlock/pkg/lock"
 	"github.com/alexandreLamarre/dlock/pkg/lock/broker"
@@ -83,4 +84,24 @@ func (lm *LockManager) NewLock(key string, opt ...lock.LockOption) lock.Lock {
 	options := lock.DefaultLockOptions()
 	options.Apply(opt...)
 	return NewLock(lm.pools, lm.quorum, lm.prefix, key, lm.lg, options)
+}
+
+func (lm *LockManager) EXLock(key string, opts ...lock.LockOption) lock.Lock {
+	return lm.NewLock(key, opts...)
+}
+
+func (lm *LockManager) PWLock(key string, opts ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+
+func (lm *LockManager) PRLock(key string, opts ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+
+func (lm *LockManager) CWLock(key string, opts ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
+}
+
+func (lm *LockManager) CRLock(key string, opts ...lock.LockOption) lock.Lock {
+	return &unimplemented.UnimplementedLock{}
 }

--- a/internal/lock/backend/unimplemented/unimplemented.go
+++ b/internal/lock/backend/unimplemented/unimplemented.go
@@ -1,0 +1,23 @@
+package unimplemented
+
+import (
+	"context"
+
+	"github.com/alexandreLamarre/dlock/pkg/lock"
+)
+
+type UnimplementedLock struct{}
+
+var _ lock.Lock = (*UnimplementedLock)(nil)
+
+func (u *UnimplementedLock) Lock(ctx context.Context) (expired <-chan struct{}, err error) {
+	return nil, lock.ErrLockTypeNotImplemented
+}
+
+func (u *UnimplementedLock) TryLock(ctx context.Context) (acquired bool, expired <-chan struct{}, err error) {
+	return false, nil, lock.ErrLockTypeNotImplemented
+}
+
+func (u *UnimplementedLock) Unlock() error {
+	return lock.ErrLockTypeNotImplemented
+}

--- a/pkg/server/lock.go
+++ b/pkg/server/lock.go
@@ -130,7 +130,7 @@ func (s *LockServer) Lock(in *v1alpha1.LockRequest, stream v1alpha1.Dlock_LockSe
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	locker := s.lm.NewLock(in.Key, lock.WithTracer(s.tracer))
+	locker := s.lm.EXLock(in.Key, lock.WithTracer(s.tracer))
 	ctx, lockSpan := s.tracer.Start(stream.Context(), "acquire-lock", trace.WithAttributes(
 		attribute.KeyValue{
 			Key:   "key",


### PR DESCRIPTION
- [] Extend the interface to provide implementations for every distributed lock type

- [ ] Implement PR,PW,CR for etcd
- [ ] Implement PR,PW,CW,CR for jetstream
- [ ] Conformance test for PR
- [ ] Conformance test for PW
- [ ] Conformance test for CW
- [ ] Conformance test for CR
- [ ] Rework GRPC api for new lock types
- [ ] Rework the SDK, 
  - [ ] Clean up what gets exported in other packages 
  - [ ] export common usecases like sync.<Objects> but for distributed settings, leader election sdk, consensus rings, etc...
